### PR TITLE
Dnd5e 3.0 converter fix

### DIFF
--- a/module.json
+++ b/module.json
@@ -3,7 +3,7 @@
     "title": "World Currency 5e",
     "description": "Use currencies unique to your world in D&D 5E.",
     "authors": [{ "name": "cstby" }],
-    "version": "2.0.3",
+    "version": "2.0.4",
     "library": "false",
     "compatibility": {
         "minimum": "10",

--- a/scripts/compatibility.js
+++ b/scripts/compatibility.js
@@ -2,23 +2,31 @@
  * Compatibility with other modules.
  */
 
-import { getCurrencySettings } from "./world-currency-5e.js";
+import { getCurrencySettings, ALT_ABRV, ALT } from "./world-currency-5e.js";
 
-/** Alters currency names on the given character sheet. */
+function changeText(currency, altAbrv) {
+    html.find(`[class="denomination ${currency}"]`).text(getCurrencySettings()[altAbrv]);
+}
+
+function swapDnd5eIcon(currency, altAbrv) {
+    html.find(`[class="currency ${currency}"]`)
+        ?.removeClass(currency)
+        ?.addClass(` ${getCurrencySettings()[altAbrv].toLowerCase()}`);
+}
+
+/** Alters currency on the given character sheet. */
 function alterCharacterCurrency(html) {
-    let altNames = getCurrencySettings();
+    changeText(html, "pp", ALT_ABRV.PP);
+    changeText(html, "gp", ALT_ABRV.GP);
+    changeText(html, "ep", ALT_ABRV.EP);
+    changeText(html, "sp", ALT_ABRV.SP);
+    changeText(html, "cp", ALT_ABRV.CP);
 
-    html.find('[class="denomination pp"]').text(altNames["ppAltAbrv"]);
-    html.find('[class="denomination gp"]').text(altNames["gpAltAbrv"]);
-    html.find('[class="denomination ep"]').text(altNames["epAltAbrv"]);
-    html.find('[class="denomination sp"]').text(altNames["spAltAbrv"]);
-    html.find('[class="denomination cp"]').text(altNames["cpAltAbrv"]);
-
-    html.find('[class="currency cp"]')?.removeClass("cp")?.addClass(` ${altNames["cpAltAbrv"].toLowerCase()}`);
-    html.find('[class="currency sp"]')?.removeClass("sp")?.addClass(` ${altNames["spAltAbrv"].toLowerCase()}`);
-    html.find('[class="currency ep"]')?.removeClass("ep")?.addClass(` ${altNames["epAltAbrv"].toLowerCase()}`);
-    html.find('[class="currency gp"]')?.removeClass("gp")?.addClass(` ${altNames["gpAltAbrv"].toLowerCase()}`);
-    html.find('[class="currency pp"]')?.removeClass("pp")?.addClass(` ${altNames["ppAltAbrv"].toLowerCase()}`);
+    swapDnd5eIcon(html, "cp", ALT_ABRV.CP);
+    swapDnd5eIcon(html, "sp", ALT_ABRV.SP);
+    swapDnd5eIcon(html, "ep", ALT_ABRV.EP);
+    swapDnd5eIcon(html, "gp", ALT_ABRV.GP);
+    swapDnd5eIcon(html, "pp", ALT_ABRV.PP);
 }
 
 // Compatibility: Let's Trade 5E
@@ -56,12 +64,12 @@ function alterPartyOverviewWindowCurrency(html) {
     let altNames = getCurrencySettings();
 
     const currencies = html.find('div[data-tab="currencies"] div.table-row.header div.text.icon');
-    $(currencies[0]).text(altNames["ppAlt"]);
-    $(currencies[1]).text(altNames["gpAlt"]);
-    $(currencies[2]).text(altNames["epAlt"]);
-    $(currencies[3]).text(altNames["spAlt"]);
-    $(currencies[4]).text(altNames["cpAlt"]);
-    $(currencies[5]).text(`${altNames["gpAlt"]} (${game.i18n.localize("party-overview.TOTAL")})`);
+    $(currencies[0]).text(altNames[ALT.PP]);
+    $(currencies[1]).text(altNames[ALT.GP]);
+    $(currencies[2]).text(altNames[ALT.EP]);
+    $(currencies[3]).text(altNames[ALT.SP]);
+    $(currencies[4]).text(altNames[ALT.CP]);
+    $(currencies[5]).text(`${altNames[ALT.GP]} (${game.i18n.localize("party-overview.TOTAL")})`);
 }
 
 export { alterCharacterCurrency, alterTradeDialogCurrency, alterTradeWindowCurrency, alterPartyOverviewWindowCurrency };

--- a/scripts/convert.js
+++ b/scripts/convert.js
@@ -1,22 +1,24 @@
 /**
  * Convert one type of currency to another.
  */
+const WORLD_CURRENCY_5E = "world-currency-5e";
+const STANDARD = "Standard";
 
 /** Converts a given value in gold to its value in the game's standard currency. */
 function gpToStandard(n) {
-    let standard = game.settings.get("world-currency-5e", "Standard");
+    let standard = game.settings.get(WORLD_CURRENCY_5E, STANDARD);
     return n * CONFIG.DND5E.currencies[standard].conversion;
 }
 
 /** Converts a given value in the game's standard currency to gold. */
 function standardToGp(n) {
-    let standard = game.settings.get("world-currency-5e", "Standard");
+    let standard = game.settings.get(WORLD_CURRENCY_5E, STANDARD);
     return n / CONFIG.DND5E.currencies[standard].conversion;
 }
 
 /** Adds the abbreviation of the standard currency after the given value. */
 function formatCurrency(n) {
-    let standard = game.settings.get("world-currency-5e", "Standard");
+    let standard = game.settings.get(WORLD_CURRENCY_5E, STANDARD);
     return String(n) + " " + CONFIG.DND5E.currencies[standard].abbreviation;
 }
 

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -30,7 +30,7 @@ Hooks.on("renderActorSheet5eVehicle", (sheet, html) => {
 });
 
 Hooks.on("renderItemSheet", (sheet, html, data) => {
-    let standard = game.settings.get("world-currency-5e", "Standard");
+    let standard = game.settings.get(core.WORLD_CURRENCY_5E, "Standard");
     if (!(game.user.isGM && standard == "gp")) {
         html.find('[name="system.price"]').prop("disabled", true);
         html.find('[name="system.price"]').prop("type", "text");
@@ -56,7 +56,7 @@ Hooks.on("renderActorSheet5eVehicle", (sheet, html) => {
         console.log("world-currency-5e | Altered Tidy5eVehicle");
     }
 
-    if (game.settings.get("world-currency-5e", "RemoveConverter")) {
+    if (game.settings.get(core.WORLD_CURRENCY_5E, "RemoveConverter")) {
         core.removeConvertCurrency(html);
     }
 });
@@ -68,7 +68,7 @@ Hooks.on("renderTradeWindow", (sheet, html) => {
 });
 
 Hooks.on("renderDialog", (sheet, html) => {
-    if (game.modules.get("world-currency-5e")?.active && sheet.title === "Incoming Trade Request") {
+    if (game.modules.get(core.WORLD_CURRENCY_5E)?.active && sheet.title === "Incoming Trade Request") {
         compatibility.alterTradeDialogCurrency(html);
         console.log("world-currency-5e | Altered Trade Dialog Currency");
     }

--- a/scripts/settings.js
+++ b/scripts/settings.js
@@ -2,11 +2,11 @@
  * Settings that allow user to specify custom currencies and other options.
  */
 
-import { patchCurrencies } from "./world-currency-5e.js";
+import { patchCurrencies, WORLD_CURRENCY_5E, ALT_REMOVE, ALT, CONVERT } from "./world-currency-5e.js";
 
 /** Registers setting to remove the currency converter from character sheets. */
 function registerSettingsConverter() {
-    game.settings.register("world-currency-5e", "RemoveConverter", {
+    game.settings.register(WORLD_CURRENCY_5E, "RemoveConverter", {
         name: "Remove currency converter from character sheets.",
         scope: "world",
         config: true,
@@ -18,7 +18,7 @@ function registerSettingsConverter() {
 
 /** Helper function that registers whether currency should be removed. */
 function registerRemove(settingName, originalName) {
-    game.settings.register("world-currency-5e", settingName + "Remove", {
+    game.settings.register(WORLD_CURRENCY_5E, settingName + "Remove", {
         name: "Hide " + originalName,
         scope: "world",
         config: true,
@@ -30,16 +30,17 @@ function registerRemove(settingName, originalName) {
 
 /** Registers settings to remove currencies */
 function registerSettingsCurrencyRemove() {
-    registerRemove("cpAlt", "Copper");
-    registerRemove("spAlt", "Silver");
-    registerRemove("epAlt", "Electrum");
-    registerRemove("gpAlt", "Gold");
-    registerRemove("ppAlt", "Platinum");
+    registerRemove(ALT.CP, "Copper");
+    registerRemove(ALT.SP, "Silver");
+    registerRemove(ALT.EP, "Electrum");
+    registerRemove(ALT.GP, "Gold");
+    registerRemove(ALT.PP, "Platinum");
 }
 
 /** Helper function that registers a new currency. */
-function registerCurrency(settingName, originalName, originalAbrv, isRemoved) {
-    game.settings.register("world-currency-5e", settingName, {
+function registerCurrency(settingName, originalName, originalAbrv, altRemove) {
+    let isRemoved = game.settings.get(WORLD_CURRENCY_5E, altRemove);
+    game.settings.register(WORLD_CURRENCY_5E, settingName, {
         name: originalName + " New Name",
         scope: "world",
         config: !isRemoved,
@@ -47,7 +48,7 @@ function registerCurrency(settingName, originalName, originalAbrv, isRemoved) {
         type: String,
         onChange: () => patchCurrencies(),
     });
-    game.settings.register("world-currency-5e", settingName + "Abrv", {
+    game.settings.register(WORLD_CURRENCY_5E, settingName + "Abrv", {
         name: originalName + " New Abbreviation",
         scope: "world",
         config: !isRemoved,
@@ -59,22 +60,16 @@ function registerCurrency(settingName, originalName, originalAbrv, isRemoved) {
 
 /** Registers settings to change names of abbreviations of currencies */
 function registerSettingsCurrencyNames() {
-    let cpAltRemove = game.settings.get("world-currency-5e", "cpAltRemove");
-    let spAltRemove = game.settings.get("world-currency-5e", "spAltRemove");
-    let epAltRemove = game.settings.get("world-currency-5e", "epAltRemove");
-    let gpAltRemove = game.settings.get("world-currency-5e", "gpAltRemove");
-    let ppAltRemove = game.settings.get("world-currency-5e", "ppAltRemove");
-
-    registerCurrency("cpAlt", "Copper", "CP", cpAltRemove);
-    registerCurrency("spAlt", "Silver", "SP", spAltRemove);
-    registerCurrency("epAlt", "Electrum", "EP", epAltRemove);
-    registerCurrency("gpAlt", "Gold", "GP", gpAltRemove);
-    registerCurrency("ppAlt", "Platinum", "PP", ppAltRemove);
+    registerCurrency(ALT.CP, "Copper", "CP", ALT_REMOVE.CP);
+    registerCurrency(ALT.SP, "Silver", "SP", ALT_REMOVE.SP);
+    registerCurrency(ALT.EP, "Electrum", "EP", ALT_REMOVE.EP);
+    registerCurrency(ALT.GP, "Gold", "GP", ALT_REMOVE.GP);
+    registerCurrency(ALT.PP, "Platinum", "PP", ALT_REMOVE.PP);
 }
 
 /** Helper function that registers an exchange rate. */
 function registerExchangeRate(exchangeSetting, newName, isRemoved) {
-    game.settings.register("world-currency-5e", exchangeSetting, {
+    game.settings.register(WORLD_CURRENCY_5E, exchangeSetting, {
         name: "How many " + newName + " in a RAW GP?",
         scope: "world",
         config: !isRemoved,
@@ -86,39 +81,39 @@ function registerExchangeRate(exchangeSetting, newName, isRemoved) {
 
 /** Registers settings to change all exchange rates. */
 function registerSettingsExchangeRates() {
-    let cpAltRemove = game.settings.get("world-currency-5e", "cpAltRemove");
-    let spAltRemove = game.settings.get("world-currency-5e", "spAltRemove");
-    let epAltRemove = game.settings.get("world-currency-5e", "epAltRemove");
-    let gpAltRemove = game.settings.get("world-currency-5e", "gpAltRemove");
-    let ppAltRemove = game.settings.get("world-currency-5e", "ppAltRemove");
+    let cpAltRemove = game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.CP);
+    let spAltRemove = game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.SP);
+    let epAltRemove = game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.EP);
+    let gpAltRemove = game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.GP);
+    let ppAltRemove = game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.PP);
 
-    let cpAlt = game.settings.get("world-currency-5e", "cpAlt");
-    let spAlt = game.settings.get("world-currency-5e", "spAlt");
-    let epAlt = game.settings.get("world-currency-5e", "epAlt");
-    let gpAlt = game.settings.get("world-currency-5e", "gpAlt");
-    let ppAlt = game.settings.get("world-currency-5e", "ppAlt");
+    let cpAlt = game.settings.get(WORLD_CURRENCY_5E, ALT.CP);
+    let spAlt = game.settings.get(WORLD_CURRENCY_5E, ALT.SP);
+    let epAlt = game.settings.get(WORLD_CURRENCY_5E, ALT.EP);
+    let gpAlt = game.settings.get(WORLD_CURRENCY_5E, ALT.GP);
+    let ppAlt = game.settings.get(WORLD_CURRENCY_5E, ALT.PP);
 
-    registerExchangeRate("cpConvert", cpAlt, cpAltRemove);
-    registerExchangeRate("spConvert", spAlt, spAltRemove);
-    registerExchangeRate("epConvert", epAlt, epAltRemove);
-    registerExchangeRate("gpConvert", gpAlt, gpAltRemove);
-    registerExchangeRate("ppConvert", ppAlt, ppAltRemove);
+    registerExchangeRate(CONVERT.CP, cpAlt, cpAltRemove);
+    registerExchangeRate(CONVERT.SP, spAlt, spAltRemove);
+    registerExchangeRate(CONVERT.EP, epAlt, epAltRemove);
+    registerExchangeRate(CONVERT.GP, gpAlt, gpAltRemove);
+    registerExchangeRate(CONVERT.PP, ppAlt, ppAltRemove);
 }
 
 /** Registers setting to set a standard currency */
 function registerSettingsStandard() {
-    game.settings.register("world-currency-5e", "Standard", {
+    game.settings.register(WORLD_CURRENCY_5E, "Standard", {
         name: "Standard Currency",
         scope: "world",
         config: true,
         default: "gp",
         type: String,
         choices: {
-            pp: game.settings.get("world-currency-5e", "ppAlt"),
-            gp: game.settings.get("world-currency-5e", "gpAlt"),
-            ep: game.settings.get("world-currency-5e", "epAlt"),
-            sp: game.settings.get("world-currency-5e", "spAlt"),
-            cp: game.settings.get("world-currency-5e", "cpAlt"),
+            pp: game.settings.get(WORLD_CURRENCY_5E, ALT.PP),
+            gp: game.settings.get(WORLD_CURRENCY_5E, ALT.GP),
+            ep: game.settings.get(WORLD_CURRENCY_5E, ALT.EP),
+            sp: game.settings.get(WORLD_CURRENCY_5E, ALT.SP),
+            cp: game.settings.get(WORLD_CURRENCY_5E, ALT.CP),
         },
         onChange: () => patchCurrencies(),
     });

--- a/scripts/world-currency-5e.js
+++ b/scripts/world-currency-5e.js
@@ -108,9 +108,11 @@ function patchCurrencies() {
 
 /** Removes the currency converter from the given character sheet. */
 function removeConvertCurrency(html) {
-    html.find('[class="currency-item convert"]').remove();
-    html.find('[data-action="convertCurrency"]').remove();
-    html.find('[title="Convert Currency"]').remove();
+    html.find('[class="currency-item convert"]')?.remove();
+    html.find('[data-action="convertCurrency"]')?.remove();
+    html.find('[title="Convert Currency"]')?.remove();
+    // tidy-sheet
+    html.find('[class="currency-item convert svelte-52d1bs"]')?.remove();
     // D&D5e 3.0
     html.find(`[class="currency"]`)?.find(`[class="item-action unbutton"]`)?.remove();
 }

--- a/scripts/world-currency-5e.js
+++ b/scripts/world-currency-5e.js
@@ -2,29 +2,59 @@
  * Core functions for patching currencies configuration.
  */
 
+const WORLD_CURRENCY_5E = "world-currency-5e";
+const CONVERT = {
+    CP: "cpConvert",
+    SP: "spConvert",
+    EP: "epConvert",
+    GP: "gpConvert",
+    PP: "ppConvert",
+};
+const ALT_REMOVE = {
+    CP: "cpAltRemove",
+    SP: "spAltRemove",
+    EP: "epAltRemove",
+    GP: "gpAltRemove",
+    PP: "ppAltRemove",
+};
+const ALT = {
+    CP: "cpAlt",
+    SP: "spAlt",
+    EP: "epAlt",
+    GP: "gpAlt",
+    PP: "ppAlt",
+};
+const ALT_ABRV = {
+    CP: "cpAltAbrv",
+    SP: "spAltAbrv",
+    EP: "epAltAbrv",
+    GP: "gpAltAbrv",
+    PP: "ppAltAbrv",
+};
+
 /** Gets the currencies specified by the user and returns them as an object.*/
 function getCurrencySettings() {
     return {
-        cpConvert: game.settings.get("world-currency-5e", "cpConvert"),
-        spConvert: game.settings.get("world-currency-5e", "spConvert"),
-        epConvert: game.settings.get("world-currency-5e", "epConvert"),
-        gpConvert: game.settings.get("world-currency-5e", "gpConvert"),
-        ppConvert: game.settings.get("world-currency-5e", "ppConvert"),
-        cpAltRemove: game.settings.get("world-currency-5e", "cpAltRemove"),
-        spAltRemove: game.settings.get("world-currency-5e", "spAltRemove"),
-        epAltRemove: game.settings.get("world-currency-5e", "epAltRemove"),
-        gpAltRemove: game.settings.get("world-currency-5e", "gpAltRemove"),
-        ppAltRemove: game.settings.get("world-currency-5e", "ppAltRemove"),
-        cpAlt: game.settings.get("world-currency-5e", "cpAlt"),
-        spAlt: game.settings.get("world-currency-5e", "spAlt"),
-        epAlt: game.settings.get("world-currency-5e", "epAlt"),
-        gpAlt: game.settings.get("world-currency-5e", "gpAlt"),
-        ppAlt: game.settings.get("world-currency-5e", "ppAlt"),
-        cpAltAbrv: game.settings.get("world-currency-5e", "cpAltAbrv"),
-        spAltAbrv: game.settings.get("world-currency-5e", "spAltAbrv"),
-        epAltAbrv: game.settings.get("world-currency-5e", "epAltAbrv"),
-        gpAltAbrv: game.settings.get("world-currency-5e", "gpAltAbrv"),
-        ppAltAbrv: game.settings.get("world-currency-5e", "ppAltAbrv"),
+        cpConvert: game.settings.get(WORLD_CURRENCY_5E, CONVERT.CP),
+        spConvert: game.settings.get(WORLD_CURRENCY_5E, CONVERT.SP),
+        epConvert: game.settings.get(WORLD_CURRENCY_5E, CONVERT.EP),
+        gpConvert: game.settings.get(WORLD_CURRENCY_5E, CONVERT.GP),
+        ppConvert: game.settings.get(WORLD_CURRENCY_5E, CONVERT.PP),
+        cpAltRemove: game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.CP),
+        spAltRemove: game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.SP),
+        epAltRemove: game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.EP),
+        gpAltRemove: game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.GP),
+        ppAltRemove: game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.PP),
+        cpAlt: game.settings.get(WORLD_CURRENCY_5E, ALT.CP),
+        spAlt: game.settings.get(WORLD_CURRENCY_5E, ALT.SP),
+        epAlt: game.settings.get(WORLD_CURRENCY_5E, ALT.EP),
+        gpAlt: game.settings.get(WORLD_CURRENCY_5E, ALT.GP),
+        ppAlt: game.settings.get(WORLD_CURRENCY_5E, ALT.PP),
+        cpAltAbrv: game.settings.get(WORLD_CURRENCY_5E, ALT_ABRV.CP),
+        spAltAbrv: game.settings.get(WORLD_CURRENCY_5E, ALT_ABRV.SP),
+        epAltAbrv: game.settings.get(WORLD_CURRENCY_5E, ALT_ABRV.EP),
+        gpAltAbrv: game.settings.get(WORLD_CURRENCY_5E, ALT_ABRV.GP),
+        ppAltAbrv: game.settings.get(WORLD_CURRENCY_5E, ALT_ABRV.PP),
     };
 }
 
@@ -32,44 +62,44 @@ function getCurrencySettings() {
 function patchCurrencies() {
     let currencySettings = getCurrencySettings();
 
-    game.i18n.translations.DND5E.CurrencyPP = currencySettings["ppAlt"];
-    game.i18n.translations.DND5E.CurrencyGP = currencySettings["gpAlt"];
-    game.i18n.translations.DND5E.CurrencyEP = currencySettings["epAlt"];
-    game.i18n.translations.DND5E.CurrencySP = currencySettings["spAlt"];
-    game.i18n.translations.DND5E.CurrencyCP = currencySettings["cpAlt"];
+    game.i18n.translations.DND5E.CurrencyPP = currencySettings[ALT.PP];
+    game.i18n.translations.DND5E.CurrencyGP = currencySettings[ALT.GP];
+    game.i18n.translations.DND5E.CurrencyEP = currencySettings[ALT.EP];
+    game.i18n.translations.DND5E.CurrencySP = currencySettings[ALT.SP];
+    game.i18n.translations.DND5E.CurrencyCP = currencySettings[ALT.CP];
 
-    game.i18n.translations.DND5E.CurrencyAbbrPP = currencySettings["ppAltAbrv"];
-    game.i18n.translations.DND5E.CurrencyAbbrGP = currencySettings["gpAltAbrv"];
-    game.i18n.translations.DND5E.CurrencyAbbrEP = currencySettings["epAltAbrv"];
-    game.i18n.translations.DND5E.CurrencyAbbrSP = currencySettings["spAltAbrv"];
-    game.i18n.translations.DND5E.CurrencyAbbrCP = currencySettings["cpAltAbrv"];
+    game.i18n.translations.DND5E.CurrencyAbbrPP = currencySettings[ALT_ABRV.PP];
+    game.i18n.translations.DND5E.CurrencyAbbrGP = currencySettings[ALT_ABRV.GP];
+    game.i18n.translations.DND5E.CurrencyAbbrEP = currencySettings[ALT_ABRV.EP];
+    game.i18n.translations.DND5E.CurrencyAbbrSP = currencySettings[ALT_ABRV.SP];
+    game.i18n.translations.DND5E.CurrencyAbbrCP = currencySettings[ALT_ABRV.CP];
 
     CONFIG.DND5E.currencies = {
         pp: {
-            label: currencySettings["ppAlt"],
-            abbreviation: currencySettings["ppAltAbrv"],
-            conversion: currencySettings["ppConvert"],
+            label: currencySettings[ALT.PP],
+            abbreviation: currencySettings[ALT_ABRV.PP],
+            conversion: currencySettings[CONVERT.PP],
         },
         gp: {
-            label: currencySettings["gpAlt"],
-            abbreviation: currencySettings["gpAltAbrv"],
+            label: currencySettings[ALT.GP],
+            abbreviation: currencySettings[ALT_ABRV.GP],
             // Added explicit rates for easier conversion later. (see gpToStandard below.)
-            conversion: currencySettings["gpConvert"],
+            conversion: currencySettings[CONVERT.GP],
         },
         ep: {
-            label: currencySettings["epAlt"],
-            abbreviation: currencySettings["epAltAbrv"],
-            conversion: currencySettings["epConvert"],
+            label: currencySettings[ALT.EP],
+            abbreviation: currencySettings[ALT_ABRV.EP],
+            conversion: currencySettings[CONVERT.EP],
         },
         sp: {
-            label: currencySettings["spAlt"],
-            abbreviation: currencySettings["spAltAbrv"],
-            conversion: currencySettings["spConvert"],
+            label: currencySettings[ALT.SP],
+            abbreviation: currencySettings[ALT_ABRV.SP],
+            conversion: currencySettings[CONVERT.SP],
         },
         cp: {
-            label: currencySettings["cpAlt"],
-            abbreviation: currencySettings["cpAltAbrv"],
-            conversion: currencySettings["cpConvert"],
+            label: currencySettings[ALT.CP],
+            abbreviation: currencySettings[ALT_ABRV.CP],
+            conversion: currencySettings[CONVERT.CP],
         },
     };
 
@@ -97,24 +127,34 @@ function removeCurrency(html, currency) {
 }
 
 function removeCurrencies(html) {
-    if (game.settings.get("world-currency-5e", "RemoveConverter")) {
+    if (game.settings.get(WORLD_CURRENCY_5E, "RemoveConverter")) {
         removeConvertCurrency(html);
     }
-    if (game.settings.get("world-currency-5e", "cpAltRemove")) {
+    if (game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.CP)) {
         removeCurrency(html, "cp");
     }
-    if (game.settings.get("world-currency-5e", "spAltRemove")) {
+    if (game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.SP)) {
         removeCurrency(html, "sp");
     }
-    if (game.settings.get("world-currency-5e", "epAltRemove")) {
+    if (game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.EP)) {
         removeCurrency(html, "ep");
     }
-    if (game.settings.get("world-currency-5e", "gpAltRemove")) {
+    if (game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.GP)) {
         removeCurrency(html, "gp");
     }
-    if (game.settings.get("world-currency-5e", "ppAltRemove")) {
+    if (game.settings.get(WORLD_CURRENCY_5E, ALT_REMOVE.PP)) {
         removeCurrency(html, "pp");
     }
 }
 
-export { getCurrencySettings, patchCurrencies, removeConvertCurrency, removeCurrencies };
+export {
+    getCurrencySettings,
+    patchCurrencies,
+    removeConvertCurrency,
+    removeCurrencies,
+    WORLD_CURRENCY_5E,
+    ALT_REMOVE,
+    ALT,
+    CONVERT,
+    ALT_ABRV,
+};


### PR DESCRIPTION
This PR contains a fix to hide the Tidy Sheet currency converter.

Also a lot of refactoring out repeated strings and logic. Most of the changes are replacing strings with constants.